### PR TITLE
Added dependency to nethserver-openvpn >= 1.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 dist/
+*.rpm
+*.tar.gz
+

--- a/nethserver-vpn-ui.spec
+++ b/nethserver-vpn-ui.spec
@@ -9,7 +9,7 @@ Source1: %{name}-cockpit.tar.gz
 
 BuildArch: noarch
 
-Requires: nethserver-firewall-base
+Requires: nethserver-firewall-base, nethserver-openvpn >= 1.9.0
 
 BuildRequires: nethserver-devtools
 


### PR DESCRIPTION
If `nethserver-vpn-ui` is updated to version 1.1.0 before `nethserver-openvpn` is updated to version 1.9.0, a bug occurs in OpenVPN RoadWarrior page on Cockpit

https://github.com/NethServer/dev/issues/5845