### PR TITLE
Fixed host duplication on reserved IP change

### DIFF
--- a/api/lib/vpn_functions.pl
+++ b/api/lib/vpn_functions.pl
@@ -174,18 +174,40 @@ sub openvpn_algorithms {
     return $ret;
 }
 
+sub openvpn_create_or_update_host {
+    my $name = shift;
+    my $ip = shift;
+
+    my $prefix = "vpn-rw-";
+    my $key = "$prefix$name";
+
+    my $ndb = esmith::HostsDB->open();
+    my $host = $ndb->get($key) || undef;
+
+    if (!$host) {
+        openvpn_create_host($name, $ip);
+    } else {
+        openvpn_update_host($name, $ip);
+    }
+}
+
+sub openvpn_update_host {
+    my $name = shift;
+    my $ip = shift;
+
+    my $prefix = "vpn-rw-";
+    my $key = "$prefix$name";
+
+    my $ndb = esmith::HostsDB->open();
+    $ndb->set_prop($key, 'IpAddress', $ip);
+}
+
 sub openvpn_create_host {
 
     my $name = shift;
     my $ip = shift;
 
-    # do nothing if the host already exists
     my $ndb = esmith::HostsDB->open();
-    foreach ($ndb->get_all_by_prop('type' => 'host')) {
-       return if ($_->prop('IpAddress') eq $ip);
-    }
-
-    my $i = 1;
     my $prefix = "vpn-rw-";
     my $key = "$prefix$name";
     while ($ndb->get($key)) {

--- a/api/openvpn-rw/update
+++ b/api/openvpn-rw/update
@@ -37,7 +37,7 @@ if ($cmd eq 'update-account') {
     }
     if ($input->{'OpenVpnIp'} ne '') {
         $input->{'name'} =~ s/(@.*)$//; # remove domain part
-        openvpn_create_host($input->{'name'}, $input->{'OpenVpnIp'});
+        openvpn_create_or_update_host($input->{'name'}, $input->{'OpenVpnIp'});
     }
 
 } elsif ($cmd eq 'configuration') {


### PR DESCRIPTION
When editing the reserved IP address for an OpenVPN account, the related
host address is now changed instead of creating a new one

https://github.com/NethServer/dev/issues/5850