### PR TITLE
Create the vpn esmith database

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -1,0 +1,31 @@
+#!/usr/bin/perl -w
+#
+# Copyright (C) 2019 Nethesis S.r.l.
+# http://www.nethesis.it - support@nethesis.it
+# 
+# This script is part of NethServer.
+# 
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+# 
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+use esmith::Build::CreateLinks  qw(:all);
+
+
+#
+# update event
+#
+
+event_actions('nethserver-vpn-ui-update', qw(
+      initialize-default-databases 00
+  ));

--- a/nethserver-vpn-ui.spec
+++ b/nethserver-vpn-ui.spec
@@ -23,6 +23,11 @@ VPN UI module for NethServer.
 %build
 sed -i 's/_RELEASE_/%{version}/' %{name}.json
 %{makedocs}
+perl createlinks
+mkdir -p root/etc/e-smith/events/%{name}-update
+
+# build the esmith vpn db
+mkdir -p root/%{_nsdbconfdir}/vpn/{migrate,force,defaults}
 
 %install
 rm -rf %{buildroot}
@@ -44,6 +49,8 @@ rm -rf $RPM_BUILD_ROOT
 
 %files -f %{name}-%{version}-filelist
 %defattr(-,root,root)
+%dir %{_nseventsdir}/%{name}-update
+%dir %{_nsdbconfdir}/vpn
 
 %changelog
 * Wed Sep 18 2019 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.1.0-1


### PR DESCRIPTION
the vpn DB does not  exist after the rpm installation, we have a blank page for the dashboard

```
[root@ns7loc9 ~]# echo '{"action":"status"}' | /usr/bin/sudo /usr/libexec/nethserver/api/nethserver-vpn-ui/dashboard/read | jq
Can't call method "get_all_by_prop" on an undefined value at /usr/libexec/nethserver/api/nethserver-vpn-ui/dashboard/read line 50.
```