### PR TITLE
ovpn tunnel api: remap tcp protocol for client

### DIFF
--- a/api/openvpn-tunnel/download-json
+++ b/api/openvpn-tunnel/download-json
@@ -34,6 +34,10 @@ function downloadJson($name)
     }
     $ret['filename'] = "$name.json";
 
+    # remap OpenVPN optino for TCP
+    if ($record['Protocol'] == 'tcp-server') {
+        $record['Protocol'] = 'tcp-client';
+    }
     $client = array(
         'name' => substr("c$name",0,13),
         'type' => 'tunnel',

--- a/api/openvpn-tunnel/download-json
+++ b/api/openvpn-tunnel/download-json
@@ -34,7 +34,7 @@ function downloadJson($name)
     }
     $ret['filename'] = "$name.json";
 
-    # remap OpenVPN optino for TCP
+    # remap OpenVPN option for TCP
     if ($record['Protocol'] == 'tcp-server') {
         $record['Protocol'] = 'tcp-client';
     }


### PR DESCRIPTION
From openvpn man:
>  For TCP operation, one peer must use --proto tcp-server and the other
  must use --proto tcp-client.

NethServer/dev#5929