### PR TITLE
api ovpn rw: delete certificate on revoke

### DIFF
--- a/api/openvpn-rw/delete
+++ b/api/openvpn-rw/delete
@@ -34,6 +34,6 @@ if($input->{'name'}) {
     my $record = $db->get($input->{'name'});
     $record->delete();
 
-    system(("/usr/libexec/nethserver/pki-vpn-revoke", $input->{'name'}));
+    system(("/usr/libexec/nethserver/pki-vpn-revoke", "-d", $input->{'name'}));
     system(("/sbin/e-smith/signal-event", "-j", "nethserver-vpn-save"));
 }


### PR DESCRIPTION
If the certificate is not deleted, the user can't be configured again
later.

NethServer/dev#5949