### PR TITLE
api: always add newline at end of files

### DIFF
--- a/api/lib/vpn_functions.pl
+++ b/api/lib/vpn_functions.pl
@@ -221,6 +221,12 @@ sub write_file {
     my $filename = shift;
     my $data = shift;
 
+    # trim to remove extra unwanted spaces
+    $data =~ s/^\s+|\s+$//g;
+    # always add a new line: this is required to generate
+    # a valid VPN configuration file
+    $data .= "\n";
+
     open(my $fh, '>', $filename) or return 0;
     print $fh $data;
     close $fh;


### PR DESCRIPTION
OpenVPN is a little bit picky about configuration file syntax.
If a psk, or a certificate, doesn't contain a new line, the generated
configuration file is invalid.

This commit backports a fix already in place inside NethGUI.

See NethGUI code: https://github.com/NethServer/nethserver-openvpn/blob/master/root/usr/share/nethesis/NethServer/Module/OpenVpnTunnels/Servers/Modify.php#L197

NethServer/dev#6103