### PR TITLE
api: support custom OpenVPN mail text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,26 @@
 # nethserver-vpn-ui
+
 VPN UI module for IPSec and OpenVPN
 
 This module provides web interface to configure IPSec and OpenVPN tunnels inside cockpit.
+
+## Custom OpenVPN mail
+
+The `read` API can send the OpenVPN mail configuration to a given mail address.
+Example:
+```
+echo '{"action":"mail","name":"myaccount","address":"user@nethserver.org"}' |  /usr/libexec/nethserver/api/nethserver-vpn-ui/openvpn-rw/read
+```
+
+The mail contains a default text that can be overridden by creating a file inside `/etc/nethserver/openvpn-mail.cfg`.
+The configuration file must contain ASCII text, the special symbol `$name` will be replaced with actual account name.
+
+Configuration example:
+```
+This is my custom mail $name account.
+```
+
+Mail result using the API invocation above:
+```
+This is my custom mail myaccount account.
+```

--- a/api/openvpn-rw/read
+++ b/api/openvpn-rw/read
@@ -232,6 +232,19 @@ Android: https://play.google.com/store/apps/details?id=net.openvpn.openvpn
 iOS: https://itunes.apple.com/it/app/openvpn-connect/id590379981
 ";
 
+    # Allow mail override
+    # The configuration file must contain the mail text.
+    # A $name variable will be replaced with the actual account name
+    my $config_file = "/etc/nethserver/openvpn-mail.cfg";
+    if (-f $config_file) {
+        # slurp file
+        my $file_content = do{ local(@ARGV,$/) = $config_file; <> };
+        # replace $name variable
+        $file_content =~ s/\$name/$name/;
+        if ($file_content) {
+            $text = $file_content;
+        }
+    }
 
     my $msg = MIME::Lite->new(
         From    => $sender,


### PR DESCRIPTION
The new '/etc/nethserver/openvpn-mail.cfg' configuration file can be
used to customize (or just translate) the mail sent by the UI

NethServer/dev#6193