### PR TITLE
Improve management of RW connections database

### DIFF
--- a/api/dashboard/read
+++ b/api/dashboard/read
@@ -59,7 +59,7 @@ if ($cmd eq 'status') {
     $rw->{'auth'} = $db->get_prop('openvpn@host-to-net', 'AuthMode');
     $rw->{'port'} = $db->get_prop('openvpn@host-to-net', 'TCPPort') || $db->get_prop('openvpn@host-to-net', 'UDPPort');
     $rw->{'interfaces'} = ['tunrw'];
-    my $top_traffic_accounts = safe_decode_json(`/usr/libexec/nethserver/api/nethserver-vpn-ui/openvpn-rw/top-traffic-accounts 2>/dev/null`);
+    my $top_traffic_accounts = safe_decode_json(`/usr/libexec/nethserver/api/nethserver-vpn-ui/openvpn-rw/top-traffic-accounts`);
     $rw->{'topTrafficAccounts'} = $top_traffic_accounts;
 
     $tunnels->{'total'} = 0;

--- a/api/openvpn-rw/accounts-last-connected
+++ b/api/openvpn-rw/accounts-last-connected
@@ -23,17 +23,26 @@
 import os
 import sqlite3
 import simplejson
+import sys
 
-conn = sqlite3.connect('/var/lib/nethserver/openvpn/connections.db')
+DATABASE_PATH = '/var/lib/nethserver/openvpn/connections.db'
+database_exists = os.path.isfile(DATABASE_PATH)
+
+if not database_exists:
+    sys.stderr.write('Error: {} does not exist. Please execute /etc/e-smith/events/actions/nethserver-openvpn-create-connections-db'.format(DATABASE_PATH))
+    sys.exit(1)
+
+conn = sqlite3.connect(DATABASE_PATH)
 c = conn.cursor()
 
 accounts = []
-rows = c.execute('''SELECT common_name, MAX(start_time) 
-					FROM connections
-					GROUP BY common_name''')
+
+rows = c.execute('''SELECT common_name, MAX(start_time)
+                    FROM connections
+                    GROUP BY common_name''')
 
 for row in rows:
-	accounts.append({'account': row[0], 'lastConnected': row[1]})
+    accounts.append({'account': row[0], 'lastConnected': row[1]})
 
 conn.close()
 print(simplejson.dumps(accounts))

--- a/api/openvpn-rw/connection-history
+++ b/api/openvpn-rw/connection-history
@@ -37,6 +37,13 @@ if time_interval != "today" and time_interval != "last_week" and time_interval !
     sys.stderr.write('Time interval must be one of "today", "last_week" or "last_month"\n')
     exit(1)
 
+DATABASE_PATH = '/var/lib/nethserver/openvpn/connections.db'
+database_exists = os.path.isfile(DATABASE_PATH)
+
+if not database_exists:
+    sys.stderr.write('Error: {} does not exist. Please execute /etc/e-smith/events/actions/nethserver-openvpn-create-connections-db'.format(DATABASE_PATH))
+    sys.exit(1)
+
 # today at 00:00 (epoch time)
 start_str = time.strftime( "%m/%d/%Y" ) + " 00:00:00"
 today_epoch = int( time.mktime( time.strptime( start_str, "%m/%d/%Y %H:%M:%S" ) ) )
@@ -48,14 +55,19 @@ elif time_interval == "last_week":
 elif time_interval == "last_month":
     start_time_since = today_epoch - (31 * 24 * 60 * 60) # 2678400 seconds in a month
 
-conn = sqlite3.connect('/var/lib/nethserver/openvpn/connections.db')
+conn = sqlite3.connect(DATABASE_PATH)
 c = conn.cursor()
 connections = []
 
-rows = c.execute('''SELECT virtual_ip_addr, remote_ip_addr, start_time, duration, bytes_received, bytes_sent 
-                    FROM connections
-                    WHERE common_name = ?
-                    AND start_time > ?''', (account, start_time_since))
+try:
+    rows = c.execute('''SELECT virtual_ip_addr, remote_ip_addr, start_time, duration, bytes_received, bytes_sent 
+                        FROM connections
+                        WHERE common_name = ?
+                        AND start_time > ?''', (account, start_time_since))
+except:
+    conn.close()
+    print(simplejson.dumps(connections))
+    sys.exit(0)
 
 for row in rows:
     virtual_ip_addr = row[0]

--- a/api/openvpn-rw/connection-history-csv
+++ b/api/openvpn-rw/connection-history-csv
@@ -22,17 +22,29 @@
 
 import sqlite3
 import datetime
+import sys
+import os
 from pytz import timezone
 
-conn = sqlite3.connect('/var/lib/nethserver/openvpn/connections.db')
+DATABASE_PATH = '/var/lib/nethserver/openvpn/connections.db'
+database_exists = os.path.isfile(DATABASE_PATH)
+
+if not database_exists:
+    sys.stderr.write('Error: {} does not exist. Please execute /etc/e-smith/events/actions/nethserver-openvpn-create-connections-db'.format(DATABASE_PATH))
+    sys.exit(1)
+
+conn = sqlite3.connect(DATABASE_PATH)
 c = conn.cursor()
 connections = []
-
-rows = c.execute('''SELECT virtual_ip_addr, remote_ip_addr, start_time, duration, bytes_received, bytes_sent, common_name
-                    FROM connections
-                    ORDER BY start_time DESC''')
-
 print("Started,Ended,Duration (seconds),User,Virtual IP,Remote IP,Received (KB),Sent (KB)")
+
+try:
+    rows = c.execute('''SELECT virtual_ip_addr, remote_ip_addr, start_time, duration, bytes_received, bytes_sent, common_name
+                        FROM connections
+                        ORDER BY start_time DESC''')
+except:
+    conn.close()
+    sys.exit(0)
 
 for row in rows:
     virtual_ip_addr = row[0]

--- a/api/openvpn-rw/read
+++ b/api/openvpn-rw/read
@@ -150,7 +150,7 @@ if ($cmd eq 'users') {
     my $db = esmith::HostsDB->open_ro();
     my $accounts_status = safe_decode_json(`/usr/libexec/nethserver/openvpn-status3 /var/spool/openvpn/host-to-net 2>/dev/null`);
     my $accounts = safe_decode_json(`/usr/libexec/nethserver/api/nethserver-vpn-ui/openvpn-rw/list-accounts 2>/dev/null`);
-    my $last_connected = safe_decode_json(`/usr/libexec/nethserver/api/nethserver-vpn-ui/openvpn-rw/accounts-last-connected 2>/dev/null`);
+    my $last_connected = safe_decode_json(`/usr/libexec/nethserver/api/nethserver-vpn-ui/openvpn-rw/accounts-last-connected`);
 
     foreach (@{$accounts}) {
         my $host = find_host($db, $_->{'OpenVpnIp'}) || '';

--- a/api/openvpn-rw/top-traffic-accounts
+++ b/api/openvpn-rw/top-traffic-accounts
@@ -26,8 +26,16 @@ import simplejson
 import time
 import subprocess
 import operator
+import sys
 
-conn = sqlite3.connect('/var/lib/nethserver/openvpn/connections.db')
+DATABASE_PATH = '/var/lib/nethserver/openvpn/connections.db'
+database_exists = os.path.isfile(DATABASE_PATH)
+
+if not database_exists:
+    sys.stderr.write('Error: {} does not exist. Please execute /etc/e-smith/events/actions/nethserver-openvpn-create-connections-db'.format(DATABASE_PATH))
+    sys.exit(1)
+
+conn = sqlite3.connect(DATABASE_PATH)
 c = conn.cursor()
 
 # today at 00:00 (epoch time)
@@ -39,20 +47,23 @@ traffic_accounts = {}
 
 # closed connections traffic
 
-rows = c.execute('''SELECT common_name, SUM(bytes_received + bytes_sent)
-						FROM connections
-						WHERE start_time > ?
-						GROUP BY common_name
-						LIMIT ?''', (today_epoch, limit))
+try:
+	rows = c.execute('''SELECT common_name, SUM(bytes_received + bytes_sent)
+							FROM connections
+							WHERE start_time > ?
+							GROUP BY common_name
+							LIMIT ?''', (today_epoch, limit))
 
-for row in rows:
-	account_name = row[0]
-	bytes_total = row[1]
+	for row in rows:
+		account_name = row[0]
+		bytes_total = row[1]
 
-	if bytes_total is not None:
-		traffic_accounts[account_name] = bytes_total
+		if bytes_total is not None:
+			traffic_accounts[account_name] = bytes_total
 
-conn.close()
+	conn.close()
+except:
+    conn.close()
 
 # live connections traffic
 


### PR DESCRIPTION
When SQLite tries to open a non-existent database file, default behavior is to create an emtpy (zero byte) database file.
Do not create connections database if it does not exist.

NethServer/dev#6242