### PR TITLE
Placeholder for the FQDN of Remote R2W

### DIFF
--- a/api/openvpn-rw/read
+++ b/api/openvpn-rw/read
@@ -88,6 +88,7 @@ if ($cmd eq 'users') {
     my $mode = $record->prop('Mode') || '';
     my $dnsServers = $db->get_prop('dns','NameServers')|| '';
     my $domainName = $db->get_value('DomainName') || '';
+    my $SystemName = $db->get_value('SystemName') || '';
     my @dns;
     my $s = new NethServer::Service('dnsmasq');
     if( $s->is_owned() && $s->is_enabled() ) {
@@ -108,8 +109,9 @@ if ($cmd eq 'users') {
     if (@dns) {
         $ret->{'Placeholders'}{Dns} = $dns[0];
         $ret->{'Placeholders'}{DomainName} = $domainName;
+        $ret->{'Placeholders'}{FullyQualifiedDomainName} = $SystemName.'.'.$domainName;
     } else {
-        $ret->{'Placeholders'} = {Dns => "", DomainName => ""};
+        $ret->{'Placeholders'} = {Dns => "", DomainName => "", FullyQualifiedDomainName => ""};
     }
 
     if ($record) {

--- a/api/openvpn-rw/validate
+++ b/api/openvpn-rw/validate
@@ -136,7 +136,7 @@ if ($data['action'] == 'create-account') {
     }
 
     $v->declareParameter('Port', Validate::PORTNUMBER);
-    $v->declareParameter('Remote', Validate::ANYTHING);
+    $v->declareParameter('Remote', Validate::NOTEMPTY);
     $v->declareParameter('Compression', $v->createValidator()->memberOf(array('disabled','lzo','lz4')));
 
     if (isset($data['Remote'])) {

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -325,7 +325,8 @@
     "port_in_use": "Port already in use",
     "invalid_certificate": "Invalid certificate",
     "valid_minLength_8": "Minimum length is 8 characters",
-    "missing_wanpriority_rules": "Missing interface in priority order"
+    "missing_wanpriority_rules": "Missing interface in priority order",
+    "valid_notEmpty":"This field cannot be empty"
   },
   "docs": {
     "more_info_about": "More info about {docsLink}.",

--- a/ui/src/views/OpenVPNRW.vue
+++ b/ui/src/views/OpenVPNRW.vue
@@ -1929,7 +1929,7 @@ export default {
         Remote:
           this.newConfiguration.Remote.length > 0
             ? this.cleanTextarea(this.newConfiguration.Remote.split("\n"))
-            : this.Placeholders.FullyQualifiedDomainName.split(),
+            : [],
         Network:
           this.newConfiguration.Mode == "routed"
             ? this.newConfiguration.Network

--- a/ui/src/views/OpenVPNRW.vue
+++ b/ui/src/views/OpenVPNRW.vue
@@ -442,6 +442,7 @@
                 >{{$t('openvpn_rw.remote_host_ip_name')}}</label>
                 <div class="col-sm-9">
                   <textarea
+                    :placeholder="Placeholders.FullyQualifiedDomainName"
                     type="text"
                     v-model="newConfiguration.Remote"
                     class="form-control min-textarea-height"
@@ -1295,6 +1296,7 @@ export default {
         }
       },
       Placeholders:{
+        FullyQualifiedDomainName: "",
         DomainName: "",
         Dns: ""
       },
@@ -1927,7 +1929,7 @@ export default {
         Remote:
           this.newConfiguration.Remote.length > 0
             ? this.cleanTextarea(this.newConfiguration.Remote.split("\n"))
-            : [],
+            : this.Placeholders.FullyQualifiedDomainName.split(),
         Network:
           this.newConfiguration.Mode == "routed"
             ? this.newConfiguration.Network


### PR DESCRIPTION
- When the property openvpn@host-to-net{'Remote'} is empty (first configuration) we display all external IP
- If you erase all of these IP, the openvpn@host-to-net{'Remote'} is saved empty
- If you download the R2W VPN configuration you will find that the used remote is the FQDN of the server
- If you go back to the configuration of the R2W VPN you will see the external IPs, but the configuration of the R2W sent to your clients use the FQDN
 

I propose to change a bit this behavior

openvpn@host-to-net{'Remote'} is empty  (first configuration) -> display all external IP in the textarea
the textarea of openvpn@host-to-net{'Remote'} is empty -> display a placeholder with the FQDN of the server
the textarea of openvpn@host-to-net{'Remote'} is saved empty -> save to openvpn@host-to-net{'Remote'} the FQDN of the server

https://github.com/NethServer/dev/issues/6337