### PR TITLE
ui. specific version for vue-good-table

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
     "moment": "^2.24.0",
     "v-tooltip": "^2.0.3",
     "vue": "^2.6.10",
-    "vue-good-table": "^2.21.1",
+    "vue-good-table": "2.21.1",
     "vue-i18n": "^8.11.2",
     "vue-js-toggle-button": "^1.3.2",
     "vue-router": "^3.0.3",


### PR DESCRIPTION
Use a specific `vue-good-table` version (2.21.1) in order to have a predictable UI and behavior

NethServer/dev#6390