### PR TITLE
Delete tunnel conntrack on disable/delete action

### DIFF
--- a/api/ipsec/delete
+++ b/api/ipsec/delete
@@ -28,9 +28,8 @@ require '/usr/libexec/nethserver/api/lib/helper_functions.pl';
 my $db = esmith::ConfigDB->open('vpn');
 
 my $input = readInput();
-my $key = $input->{'name'};
-
+my $remoteIP = $db->get_prop($input->{'name'},'right');
 my $record = $db->get($input->{'name'});
 $record->delete();
 
-system(("/sbin/e-smith/signal-event", "-j", "nethserver-ipsec-tunnels-modify", "delete", $input->{'name'}));
+system(("/sbin/e-smith/signal-event", "-j", "nethserver-ipsec-tunnels-modify", "delete", $input->{'name'}, $remoteIP));


### PR DESCRIPTION
When you delete or disable an IPSEC tunnel the conntrack connection of the remote IP are not deleted, this try to fix a multiwan issue  when one red wan might fail down, the vpn tunnel uses the another red wan.

linked to https://github.com/NethServer/nethserver-ipsec-tunnels/pull/15

NethServer/dev#6393