### PR TITLE
No space for name ipset property

### DIFF
--- a/api/ipsec/validate
+++ b/api/ipsec/validate
@@ -101,6 +101,10 @@ $v->declareParameter('pfs', $yn);
 $v->declareParameter('compress', $yn);
 $v->declareParameter('dpdaction', $yn);
 
+if( preg_match("/ /", $data['name'])) {
+    $v->addValidationError('name', 'ipsec_tunnel_name_cannot_contain_spaces');
+}
+
 # Validate the input
 if ($v->validate()) {
     success();

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -329,6 +329,7 @@
     "valid_minLength_8": "Minimum length is 8 characters",
     "missing_wanpriority_rules": "Missing interface in priority order",
     "valid_notEmpty":"This field cannot be empty",
+    "ipsec_tunnel_name_cannot_contain_spaces": "Tunnel name can't contain spaces",
     "valid_username":"First character must be a letter, than only lower letters, numbers and symbols like '-' and '_'"
   },
   "docs": {


### PR DESCRIPTION
We can create in cockpit an ipset tunnel with space inside the string. Our code break with it 

```
Mar 25 09:33:34 ns79 systemd: Starting Internet Key Exchange (IKE) Protocol Daemon for IPsec...
Mar 25 09:33:34 ns79 addconn: cannot load config '/etc/ipsec.conf': /etc/ipsec.d/tunnels.conf:15: syntax error, unexpected STRING, expecting EOL [spazio_ipsec-tunnel]
```
We cannot have also spaces at the start and at the end of the key name, we use it later for leftid and rightid
```
conn aaaaaaa_ipsec-tunnel
    authby=secret
    auto=start
    compress=no
    dpdaction=hold
    dpddelay=30
    dpdtimeout=120
    left=192.168.100.7
    leftid=@     aaaaaaa     .local
    leftsourceip=192.168.56.7
    leftsubnets={ 192.168.56.0/24 }
    pfs=yes
    right=1.1.1.1
    rightid=@     aaaaaaa     .remote
    rightsubnets={ 192.168.56.0/24 }
```
https://github.com/NethServer/dev/issues/6469