### PR TITLE
Fix the display of VPN Network Row in openvpn tunnel

### DIFF
--- a/ui/src/views/OpenVPNTun.vue
+++ b/ui/src/views/OpenVPNTun.vue
@@ -131,7 +131,7 @@
                 <span v-if="props.column.field == 'Topology'" :class="['fancy', props.row.status == 'enabled' ? '': 'gray']">
                   <b>{{ props.row.Topology | uppercase}}</b>
                 </span>
-                <span v-if="props.column.field == props.row.Network ? props.row.Network : props.row.LocalPeer"
+                 <span v-if="props.column.field == 'Network'"
                   :class="['fancy', props.row.status == 'enabled' ? '': 'gray']"
                 >{{ props.row.Network ? props.row.Network : props.row.LocalPeer+" - "+ props.row.RemotePeer}}</span>
                 <span v-if="props.column.field == 'LocalNetworks'" :class="['fancy', props.row.status == 'enabled' ? '': 'gray']">
@@ -1493,20 +1493,9 @@ export default {
         },
         {
           label: this.$i18n.t("openvpn_tun.vpn_network"),
-          field: function(rowObj) {
-            return rowObj.Network ? rowObj.Network : rowObj.LocalPeer;
-          },
+          field: "Network",
           filterable: true,
-          sortFn: function(a, b, col, rowX, rowY) {
-            a = a.indexOf("-") > -1 ? a.split("-")[0] : a;
-            b = b.indexOf("-") > -1 ? b.split("-")[0] : b;
-            a = a.split(".");
-            b = b.split(".");
-            for (var i = 0; i < a.length; i++) {
-              if ((a[i] = parseInt(a[i])) < (b[i] = parseInt(b[i]))) return -1;
-              else if (a[i] > b[i]) return 1;
-            }
-          }
+          sortable: false
         },
         {
           label: this.$i18n.t("openvpn_tun.local_networks"),


### PR DESCRIPTION
The row display of P2P is broken in the openvpn tunnel let see it in image

![Screenshot - 2021-06-04T122826 841](https://user-images.githubusercontent.com/3164851/120788526-b9b9dd80-c530-11eb-98d6-af3834aaeef5.png)

This comes because we use a ternary to determine the row label with a function to sort two different values of properties (xxx.xxx.xxx.xxx./xx and xxx.xxx.xxx.xxx - xxx.xxx.xxx.xxx) 

The code is complex, I propose to remove the sortable function

![Screenshot - 2021-06-04T122940 213](https://user-images.githubusercontent.com/3164851/120788778-02719680-c531-11eb-9fa3-54a237eccf3e.png)

