### PR TITLE
Tunnel name must be shorter for client name (10 max)

### DIFF
--- a/api/openvpn-tunnel/validate
+++ b/api/openvpn-tunnel/validate
@@ -94,13 +94,13 @@ if ($data['action'] == 'update-client' || $data['action'] == 'update-server') {
     if ($sdb->getKey($data['name'])) {
         $v->addValidationError('name', 'tunnel_already_exists');
     }
+    $v->declareParameter('name', $v->createValidator(Validate::USERNAME)->maxLength(10));
     validate_wrapper($data, 'Port');
     if ($data['Topology'] == 'subnet') {
         validate_wrapper($data, 'Network');
     }
 }
 
-$v->declareParameter('name', $v->createValidator(Validate::USERNAME)->maxLength(13));
 $v->declareParameter('Port', Validate::PORTNUMBER);
 $v->declareParameter('RemotePort', Validate::PORTNUMBER);
 $v->declareParameter('Network', $v->createValidator()->cidrBlock());

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -332,6 +332,7 @@
     "missing_wanpriority_rules": "Missing interface in priority order",
     "valid_notEmpty":"This field cannot be empty",
     "ipsec_tunnel_name_cannot_contain_spaces": "Tunnel name can't contain spaces",
+    "valid_maxLength_10":"The maximum length is 10 characters",
     "valid_username":"First character must be a letter, than only lower letters, numbers and symbols like '-' and '_'"
   },
   "docs": {


### PR DESCRIPTION
When you create an openvpn tunnel you are limited to 13 characters but when you create the tunnel on the other side, the maximum length is 15 caracters

Tunnel name : 
montesanto61
montesanto62

NIC Client  tunnel name created for these tunnels
tuncmontesanto6 


https://github.com/NethServer/dev/issues/6538