### PR TITLE
list-accounts: improve performance

### DIFF
--- a/api/openvpn-rw/list-accounts
+++ b/api/openvpn-rw/list-accounts
@@ -51,8 +51,9 @@ function readCertIndexAccounts() {
     $domain = $db->getType('DomainName');
     // get all vpn-users linked to system users
     $users = getUsers();
+    $vpn_users = $vdb->getAll("vpn");
     foreach($users as $user => $props) {
-        $vpn_user = $vdb->getKey($user);
+        $vpn_user = isset($vpn_users[$user]) ? $vpn_users[$user] : null ;
         if ($vpn_user) {
             $status =  isset($vpn_user['status']) ? $vpn_user['status'] : 'enabled';
             list($short, $domain) = explode("@", $user);
@@ -68,8 +69,7 @@ function readCertIndexAccounts() {
         }
     }
     // get all vpn accounts
-    $users = $vdb->getAll('vpn');
-    foreach($users as $user => $props) {
+    foreach($vpn_users as $user => $props) {
         $status =  isset($props['status']) ? $props['status'] : 'enabled';
         $ret[$user] = array(
             'name' => $user,


### PR DESCRIPTION
If smwingsd is not running, the call to getKey function is converted
to a call to the 'db' command. Even on a database with a small number
of records, such implementation has a huge impact on performances.

The fix reads calls the 'db' command just once and store the results
in RAM. On a database with only 30 records, the script is now 10x
faster.